### PR TITLE
Fix NullPointerException if given input is null

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/commons/Encoder.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/commons/Encoder.java
@@ -96,7 +96,12 @@ public class Encoder {
    */
   private String encodeInternal(final String input) {
     StringBuilder resultStr = new StringBuilder();
-
+    
+    // avoid NPE if the given input is null
+    if (input == null) {
+        return null;
+    }
+    
     try {
       for (byte utf8Byte : input.getBytes("UTF-8")) {
         final char character = (char) utf8Byte;


### PR DESCRIPTION
in current Encoder implementation, if given input is null, an NPE would be thrown 

The scenario would be, consider an Entity which key is allowed to be null in Edmx, thus, the data retrieved in data source would be a HashMap only with non-null value, when createEntryKey<-createSelfLink, we generate the key representation from the given data, some of the key would be null and passed to Encoder, which would throw NullPointerException